### PR TITLE
Remove legacy API usage, restore IIFE wrapper for proper scoping

### DIFF
--- a/src/incubator-tooltip.html
+++ b/src/incubator-tooltip.html
@@ -125,11 +125,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
         connectedCallback() {
           if (!this._targetElement) {
-            this._targetElement = Polymer.dom(this).parentNode.querySelector(`#${this.for}`);
+            this._targetElement = this.parentNode.querySelector(`#${this.for}`);
           }
           if (this._targetElement && !this.isAttached) {
             this.isAttached = true;
-            Polymer.dom(this._targetElement).appendChild(this);
+            this._targetElement.appendChild(this);
           }
 
           this._attachToTarget();

--- a/src/incubator-tooltip.html
+++ b/src/incubator-tooltip.html
@@ -36,7 +36,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
   </template>
 
   <script>
-    {
+    (function() {
+      'use strict';
+
       /**
        * `<incubator-tooltip>` is a template for incubator components.
        *
@@ -257,6 +259,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       if (window.Vaadin.runIfDevelopmentMode) {
         window.Vaadin.runIfDevelopmentMode('vaadin-license-checker', IncubatorTooltip);
       }
-    }
+    })();
   </script>
 </dom-module>


### PR DESCRIPTION
1. `Polymer.dom` is not needed for class-based elements, see [upgrade guide](https://www.polymer-project.org/2.0/docs/upgrade#class-based-and-legacy-elements-use-native-dom-methods). BTW, you do not import this legacy stuff in the component so it relies on it being imported elsewhere.

2. ES6 block scoping is not preserved when transpiling to ES5, which causes unexpected weird results in old browsers, see vaadin/vaadin-element-skeleton#92