### PR TITLE
target element and for properties - dynamically

### DIFF
--- a/demo/incubator-tooltip-basic-demos.html
+++ b/demo/incubator-tooltip-basic-demos.html
@@ -71,6 +71,63 @@
       </script>
     </vaadin-demo-snippet>
 
+    <h3>Dynamic tooltip modifying for property</h3>
+    <vaadin-demo-snippet id="incubator-tooltip-demo-sample-4">
+      <template preserve-content>
+        <vaadin-button id="demo-btn1">
+          Button 1
+        </vaadin-button>
+        <vaadin-button id="demo-btn2">
+          Button 2
+        </vaadin-button>
+        <vaadin-button id="action-button">
+          Action button
+        </vaadin-button>
+        <incubator-tooltip id="my-tooltip" position="right" align="bottom">
+          A tooltip to remember.
+        </incubator-tooltip>
+      </template>
+      <script>
+        window.addDemoReadyListener('#incubator-tooltip-demo-sample-4', function (document) {
+          const tooltipElement = document.querySelector('#my-tooltip');
+          const btn = document.querySelector('#action-button');
+          let i = 1;
+          btn.addEventListener('click', () => {
+              tooltipElement.for = "demo-btn" + i;
+              i = ( i == 1) ? 2 : 1;
+          });
+        });
+      </script>
+    </vaadin-demo-snippet>
+
+    <h3>Dynamic tooltip modifying targetElement property</h3>
+    <vaadin-demo-snippet id="incubator-tooltip-demo-sample-5">
+      <template preserve-content>
+        <vaadin-button id="demo-btn1">
+          Button 1
+        </vaadin-button>
+        <vaadin-button id="demo-btn2">
+          Button 2
+        </vaadin-button>
+        <vaadin-button id="action-button">
+          Action button
+        </vaadin-button>
+        <incubator-tooltip id="my-tooltip" position="right" align="bottom">
+          A tooltip to remember.
+        </incubator-tooltip>
+      </template>
+      <script>
+        window.addDemoReadyListener('#incubator-tooltip-demo-sample-5', function (document) {
+          const tooltipElement = document.querySelector('#my-tooltip');
+          const btn = document.querySelector('#action-button');
+          let i = 1;
+          btn.addEventListener('click', () => {
+              tooltipElement.targetElement = document.querySelector('#demo-btn' + i);
+              i = ( i == 1) ? 2 : 1;
+          });
+        });
+      </script>
+    </vaadin-demo-snippet>
   </template>
   <script>
     class VaadinTooltipBasicDemos extends DemoReadyEventEmitter(ElementDemo(Polymer.Element)) {

--- a/demo/incubator-tooltip-basic-demos.html
+++ b/demo/incubator-tooltip-basic-demos.html
@@ -71,7 +71,12 @@
       </script>
     </vaadin-demo-snippet>
 
-    <h3>Dynamic tooltip modifying for property</h3>
+    <h3>Dynamic tooltip modifying "for" property</h3>
+    <p>
+      When the "Change Tooltip" button is clicked, the tooltip changes
+      from one button to the other one. Before clicking on the button the
+      tooltip is not set. 
+     </p>
     <vaadin-demo-snippet id="incubator-tooltip-demo-sample-4">
       <template preserve-content>
         <vaadin-button id="demo-btn1">
@@ -81,7 +86,7 @@
           Button 2
         </vaadin-button>
         <vaadin-button id="action-button">
-          Action button
+          Change Tooltip
         </vaadin-button>
         <incubator-tooltip id="my-tooltip" position="right" align="bottom">
           A tooltip to remember.
@@ -101,6 +106,11 @@
     </vaadin-demo-snippet>
 
     <h3>Dynamic tooltip modifying targetElement property</h3>
+    <p>
+     When the "Change Tooltip" button is clicked, the tooltip changes
+     from one button to the other one. Before clicking on the button the
+     tooltip is not set. 
+    </p>
     <vaadin-demo-snippet id="incubator-tooltip-demo-sample-5">
       <template preserve-content>
         <vaadin-button id="demo-btn1">
@@ -110,7 +120,7 @@
           Button 2
         </vaadin-button>
         <vaadin-button id="action-button">
-          Action button
+          Change Tooltip
         </vaadin-button>
         <incubator-tooltip id="my-tooltip" position="right" align="bottom">
           A tooltip to remember.

--- a/src/incubator-tooltip.html
+++ b/src/incubator-tooltip.html
@@ -109,6 +109,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               reflectToAttribute: true
             },
 
+            /**
+             * The tooltip is attached to this element.
+             */
             targetElement: {
               type: Object,
               observer: '_attachToTarget'

--- a/src/incubator-tooltip.html
+++ b/src/incubator-tooltip.html
@@ -109,24 +109,17 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               reflectToAttribute: true
             },
 
-            /**
-             * If the element is mounted to the DOM.
-             */
-            isAttached: {
-              type: Boolean,
-              value: false
-            },
-
-            _targetElement: {
-              type: Object
+            targetElement: {
+              type: Object,
+              observer: '_attachToTarget'
             }
           };
         }
 
         static get observers() {
           return [
-            '_setPosition(isAttached, hidden, position, align)',
-            '_attachToTarget(for, isAttached)',
+            '_setPosition(targetElement, hidden, position, align)',
+            '_updateTarget(for)',
             '_manualObserver(manual)'
           ];
         }
@@ -138,10 +131,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
 
         connectedCallback() {
-          if (!this._targetElement) {
-            this._targetElement = this.parentNode.querySelector(`#${this.for}`);
-            this.isAttached = true;
-          }
           this._attachToTarget();
           super.connectedCallback();
         }
@@ -159,20 +148,23 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
-        _attachToTarget() {
-          if (!this.isAttached) {
+        _attachToTarget(newValue,oldValue) {
+          if (oldValue) {
+            this._removeTargetEvents(oldValue);
+          }
+          if (!this.targetElement) {
             return;
           }
           this._addEvents();
         }
         
         _addEvents() {
-          if (this._targetElement && !this.manual) {
-            this._targetElement.addEventListener('mouseenter', this._boundShow);
-            this._targetElement.addEventListener('focus', this._boundShow);
-            this._targetElement.addEventListener('mouseleave', this._boundHide);
-            this._targetElement.addEventListener('blur', this._boundHide);
-            this._targetElement.addEventListener('tap', this._boundHide);
+          if (this.targetElement && !this.manual) {
+            this.targetElement.addEventListener('mouseenter', this._boundShow);
+            this.targetElement.addEventListener('focus', this._boundShow);
+            this.targetElement.addEventListener('mouseleave', this._boundHide);
+            this.targetElement.addEventListener('blur', this._boundHide);
+            this.targetElement.addEventListener('tap', this._boundHide);
           }
 
           if (!this.manual) {
@@ -188,26 +180,34 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
 
         _removeEvents() {
-          if (this._targetElement) {
-            this._targetElement.removeEventListener('mouseenter', this._boundShow);
-            this._targetElement.removeEventListener('focus', this._boundShow);
-            this._targetElement.removeEventListener('mouseleave', this._boundHide);
-            this._targetElement.removeEventListener('blur', this._boundHide);
-            this._targetElement.removeEventListener('tap', this._boundHide);
+          if (this.targetElement) {
+            this._removeTargetEvents(this.targetElement);
           }
           this.removeEventListener('mouseenter', this._boundShow);
           this.removeEventListener('mouseleave', this._boundHide);
         }
 
-        _setPosition(isAttached, hidden, position) {
-          if (!isAttached || hidden) {
+        _removeTargetEvents(target) {
+          target.removeEventListener('mouseenter', this._boundShow);
+          target.removeEventListener('focus', this._boundShow);
+          target.removeEventListener('mouseleave', this._boundHide);
+          target.removeEventListener('blur', this._boundHide);
+          target.removeEventListener('tap', this._boundHide);
+        }
+        
+        _updateTarget(){
+          this.targetElement = this.parentNode.querySelector(`#${this.for}`);
+        }
+
+        _setPosition(targetElement, hidden, position) {
+          if (!targetElement|| hidden) {
             return;
           }
           const parentRect = this.offsetParent.getBoundingClientRect();
           const parentRectTop = parentRect.top;
           const parentRectLeft = parentRect.left;
           const parentRectHeight = parentRect.height;
-          const targetRect = this._targetElement.getBoundingClientRect();
+          const targetRect = this.targetElement.getBoundingClientRect();
           const thisRect = this.getBoundingClientRect();
           const targetLeft = targetRect.left;
           const targetTop = targetRect.top;


### PR DESCRIPTION
It allows the user to change the target element and the id dynamically.

Now the user can set the target element without specifying the id.

The property isAttached was removed because it is the same as !targetElement.